### PR TITLE
升級 electron 至 28.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "qstart-electron": "npm run qswitch-electron && TRILIUM_SAFE_MODE=1 TRILIUM_DATA_DIR=./data TRILIUM_SYNC_SERVER_HOST=http://tsyncserver:4000 TRILIUM_ENV=dev electron --inspect=5858 .",
     "start-test-server": "npm run qswitch-server; rm -rf ./data-test; cross-env TRILIUM_SAFE_MODE=1 TRILIUM_DATA_DIR=./data-test TRILIUM_SYNC_SERVER_HOST=http://tsyncserver:4000 TRILIUM_ENV=dev TRILIUM_PORT=9999 node src/www.js",
     "switch-server": "rm -rf ./node_modules/better-sqlite3 && npm install",
-    "switch-electron": "./node_modules/.bin/electron-rebuild",
+    "switch-electron": "npx electron-rebuild",
     "qswitch-server": "rm -rf ./node_modules/better-sqlite3/bin ; mkdir -p ./node_modules/better-sqlite3/build ; cp ./bin/better-sqlite3/linux-server-better_sqlite3.node ./node_modules/better-sqlite3/build/better_sqlite3.node",
     "qswitch-electron": "rm -rf ./node_modules/better-sqlite3/bin ; mkdir -p ./node_modules/better-sqlite3/build ; cp ./bin/better-sqlite3/linux-desktop-better_sqlite3.node ./node_modules/better-sqlite3/build/better_sqlite3.node",
     "build-backend-docs": "rm -rf ./docs/backend_api && ./node_modules/.bin/jsdoc -c jsdoc-conf.json -d ./docs/backend_api src/becca/entities/*.js src/services/backend_script_api.js src/services/sql.js",
@@ -31,7 +31,8 @@
     "test-jasmine": "TRILIUM_DATA_DIR=~/trilium/data-test jasmine",
     "test-es6": "node -r esm spec-es6/attribute_parser.spec.js ",
     "test": "npm run test-jasmine && npm run test-es6",
-    "postinstall": "rimraf ./node_modules/canvas"
+    "postinstall": "rimraf ./node_modules/canvas",
+    "electron-rebuild": "npx electron-rebuild"
   },
   "dependencies": {
     "@braintree/sanitize-url": "6.0.4",
@@ -40,7 +41,7 @@
     "archiver": "7.0.0",
     "async-mutex": "0.4.1",
     "axios": "1.6.7",
-    "better-sqlite3": "8.7.0",
+    "better-sqlite3": "9.2.2",
     "boxicons": "2.1.4",
     "chokidar": "3.6.0",
     "cls-hooked": "4.2.2",
@@ -109,11 +110,11 @@
     "yauzl": "3.1.2"
   },
   "devDependencies": {
+    "@electron/rebuild": "^3.6.2",
     "cross-env": "7.0.3",
-    "electron": "25.9.8",
+    "electron": "28.2.7",
     "electron-builder": "24.13.3",
     "electron-packager": "17.1.2",
-    "electron-rebuild": "3.2.9",
     "esm": "3.2.25",
     "jasmine": "5.1.0",
     "jsdoc": "4.0.2",

--- a/src/app.js
+++ b/src/app.js
@@ -26,10 +26,10 @@ app.use(helmet({
     crossOriginEmbedderPolicy: false
 }));
 
-app.use(express.text({limit: '500mb'}));
-app.use(express.json({limit: '500mb'}));
-app.use(express.raw({limit: '500mb'}));
-app.use(express.urlencoded({extended: false}));
+app.use(express.text({ limit: '500mb' }));
+app.use(express.json({ limit: '500mb' }));
+app.use(express.raw({ limit: '500mb' }));
+app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public/root')));
 app.use(`/manifest.webmanifest`, express.static(path.join(__dirname, 'public/manifest.webmanifest')));
@@ -54,7 +54,8 @@ require('./services/consistency_checks.js');
 require('./services/scheduler.js');
 
 if (utils.isElectron()) {
-    require('@electron/remote/main').initialize();
+    const { initialize } = require('@electron/remote/main');
+    initialize();
 }
 
 module.exports = app;


### PR DESCRIPTION
更新 package.json 中的 better-sqlite3 套件版本至 9.2.2，升級 electron 至 28.2.7，並調整 electron-rebuild 的執行方式為 npx。修正 app.js 和 window.js 中的程式碼格式，並啟用 @electron/remote 的功能。